### PR TITLE
feature/google → main

### DIFF
--- a/api/google/config.go
+++ b/api/google/config.go
@@ -1,0 +1,20 @@
+// GoogleAPIのconfig設定用パッケージ
+package google
+
+import (
+	"golang.org/x/oauth2"
+)
+
+// NewConfig
+// oauth2のConfigを生成
+// param scopes : スコープ
+// return *oauth.Config
+func (c *Client) NewConfig(scopes ...string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     c.ClientID,
+		ClientSecret: c.ClientSecret,
+		RedirectURL:  c.RedirectURL,
+		Scopes:       scopes,
+		Endpoint:     c.EndPoint,
+	}
+}

--- a/api/google/functions.go
+++ b/api/google/functions.go
@@ -17,7 +17,9 @@ func Auth(ctx context.Context) (*http.Response, error) {
 	c := NewClient()
 	// configのセット
 	conf := c.NewConfig("openid", "email", "profile")
+	// ユーザーをGoogle同意ページにリダイレクトし、上記で指定したスコープの許可を求める
 	url := conf.AuthCodeURL("state")
+	// 交換コードを処理してトランスポートを開始
 	tok, err := conf.Exchange(ctx, "authorization-code", oauth2.AccessTypeOffline)
 	if err != nil {
 		return nil, err

--- a/api/google/functions.go
+++ b/api/google/functions.go
@@ -1,0 +1,28 @@
+// GoogleのAPI処理用パッケージ
+package google
+
+import (
+	"context"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+// Auth
+// param ctx : コンテキスト
+// return レスポンス
+// return エラー情報
+func Auth(ctx context.Context) (*http.Response, error) {
+	// クライアント生成
+	c := NewClient()
+	// configのセット
+	conf := c.NewConfig("openid", "email", "profile")
+	url := conf.AuthCodeURL("state")
+	tok, err := conf.Exchange(ctx, "authorization-code", oauth2.AccessTypeOffline)
+	if err != nil {
+		return nil, err
+	}
+
+	client := conf.Client(ctx, tok)
+	return client.Get(url)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce Google OAuth2 config creation on Client and an Auth helper that initializes the flow and returns the HTTP response.
> 
> - **Google OAuth2**:
>   - Add `api/google/config.go`:
>     - `(*Client).NewConfig(scopes ...string)` builds `oauth2.Config` from `Client` fields and provided scopes.
>   - Add `api/google/functions.go`:
>     - `Auth(ctx)` creates a `Client`, builds config with `openid`, `email`, `profile`, generates auth URL, exchanges code, creates HTTP client, and performs `GET` to the auth URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dc19bb07dd0b1f0454947810e6b86debe6a2c8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->